### PR TITLE
11.0 add search filter

### DIFF
--- a/l10n_ar_point_of_sale/__manifest__.py
+++ b/l10n_ar_point_of_sale/__manifest__.py
@@ -45,6 +45,7 @@
         "views/iibb_situation_view.xml",
         "views/res_users_view.xml",
         "views/menuitems.xml",
+        "views/sale_order_view.xml",
     ],
     "installable": True,
     "application": True,

--- a/l10n_ar_point_of_sale/views/account_invoice_view.xml
+++ b/l10n_ar_point_of_sale/views/account_invoice_view.xml
@@ -271,17 +271,6 @@
             <field name="name">Vendor Credit Notes</field>
         </record>
 
-
-        <record id="description_internal_tree_search" model="ir.ui.view">
-          <field name="name">account.invoice.description.internal.search</field>
-          <field name="model">account.invoice</field>
-          <field name="arch" type="xml">
-            <search string="Description for Internal">
-              <field name="partner_id"/>
-            </search>
-          </field>
-        </record>
-
         <!--Inherit account invoice search view-->
         <record id="view_acoount_invoice_inherit_search" model="ir.ui.view">
           <field name="name">account.invoice.search.expand.filter</field>

--- a/l10n_ar_point_of_sale/views/account_invoice_view.xml
+++ b/l10n_ar_point_of_sale/views/account_invoice_view.xml
@@ -271,5 +271,32 @@
             <field name="name">Vendor Credit Notes</field>
         </record>
 
+
+        <record id="description_internal_tree_search" model="ir.ui.view">
+          <field name="name">account.invoice.description.internal.search</field>
+          <field name="model">account.invoice</field>
+          <field name="arch" type="xml">
+            <search string="Description for Internal">
+              <field name="partner_id"/>
+            </search>
+          </field>
+        </record>
+
+        <!--Inherit account invoice search view-->
+        <record id="view_acoount_invoice_inherit_search" model="ir.ui.view">
+          <field name="name">account.invoice.search.expand.filter</field>
+          <field name="model">account.invoice</field>
+          <field name="inherit_id" ref="account.view_account_invoice_filter"/>
+          <field name="arch" type="xml">
+
+            <xpath expr="//search" position="inside">
+              <field name="invoice_line_ids" string="Notas - Contiene" filter_domain="[('invoice_line_ids.product_id.description','ilike',self)]"/>
+            </xpath>
+
+          </field>
+        </record>
+
+
+
     </data>
 </odoo>

--- a/l10n_ar_point_of_sale/views/sale_order_view.xml
+++ b/l10n_ar_point_of_sale/views/sale_order_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+
+      <!--Inherit sale order search view-->
+      <record id="view_sale_order_inherit_search_view" model="ir.ui.view">
+        <field name="name">sale.order.search.expand.filter.view</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_sales_order_filter"/>
+        <field name="arch" type="xml">
+
+          <xpath expr="//search" position="inside">
+            <field name="order_line" string="Notas - Contiene" filter_domain="[('order_line.product_id.description','ilike',self)]"/>
+          </xpath>
+
+        </field>
+      </record>
+
+    </data>
+</odoo>

--- a/l10n_ar_point_of_sale/views/sale_order_view.xml
+++ b/l10n_ar_point_of_sale/views/sale_order_view.xml
@@ -8,11 +8,9 @@
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_sales_order_filter"/>
         <field name="arch" type="xml">
-
           <xpath expr="//search" position="inside">
             <field name="order_line" string="Notas - Contiene" filter_domain="[('order_line.product_id.description','ilike',self)]"/>
           </xpath>
-
         </field>
       </record>
 


### PR DESCRIPTION
Tarea Macro SE-302:

Añadir el filtro personalizado "Notas - Contiene" en Ventas-Pedidos / Facturas- Clientes y Proveedores. Las descripciones de productos son muy extensas; la idea sería poder filtrar por las notas Description For Internal de los productos. Este sería el campo “description”.

Nota de Felipe:

Modulo trabajado: **l10n_ar_point_of_sale**
Los filtros fueron agregados como herencias de los modelos `'sale.order' `y `'account.invoice'`

Link al Jira: [SE-302](https://eeproyectos.atlassian.net/browse/SE-302)