### PR TITLE
[SE-413] domain change

### DIFF
--- a/l10n_ar_retentions/views/payment_order_view.xml
+++ b/l10n_ar_retentions/views/payment_order_view.xml
@@ -38,7 +38,7 @@
                             <group>
                                 <group string="Information" name="info">
                                     <field name="state_id" invisible="1"/>
-                                    <field name="retention_id" domain="[('type_tax_use', '=', 'sale')]"
+                                    <field name="retention_id" domain="[('type_tax_use', '=', 'purchase')]"
                                         attrs="{'readonly': [('parent.disable_retentions', '=', False)]}"/>
                                     <field name="certificate_no"
                                         attrs="{'readonly': [('parent.disable_retentions', '=', False)]}"/>


### PR DESCRIPTION
**Tarea [SE-413]:** Al emitir un pago a proveedores al cual se le aplican retenciones el sistema trae las cuentas de "Retenciones sufridas" y corresponde que sean las "Retenciones efectuadas".

**Nota de Cris:** en la vista l10n_ar_retentions.view_vendor_payment_retention_form_extended_inherit, modificar la siguiente linea para que quede asi:

    <field name="retention_id" domain="[('type_tax_use', '=', 'purchase')]" attrs="{'readonly': [('parent.disable_retentions', '=', False)]}"/>

**Nota de Felipe:** Se aplica la solución de Cris y funciona todo bien.

**Link al Jira**: https://eeproyectos.atlassian.net/browse/SE-413